### PR TITLE
make description of matching context non mandatory

### DIFF
--- a/app/DoctrineMigrations/Version20160929151730.php
+++ b/app/DoctrineMigrations/Version20160929151730.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20160929151730 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE matching_context CHANGE description description VARCHAR(255) DEFAULT NULL');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE matching_context CHANGE description description VARCHAR(255) NOT NULL COLLATE utf8_unicode_ci');
+    }
+}

--- a/src/AppBundle/Entity/MatchingContext.php
+++ b/src/AppBundle/Entity/MatchingContext.php
@@ -36,7 +36,7 @@ class MatchingContext
     /**
      * @var string
      *
-     * @ORM\Column(name="description", type="string", length=255)
+     * @ORM\Column(name="description", type="string", length=255, nullable=true)
      */
     private $description;
 


### PR DESCRIPTION
Maarten et Benjamin sont d'accord sur le fait que ce champs ne doit pas être obligatoire (n'apparaissant de toute façon pas sur l'extension)
