### PR TITLE
use http in dev, https in prod

### DIFF
--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -1,22 +1,27 @@
 app:
     resource: "@AppBundle/Controller/"
     type:     annotation
+    schemes: [https]
 
 fos_user:
     resource: "@FOSUserBundle/Resources/config/routing/all.xml"
+    schemes: [https]
 
 api_v1:
     resource: "@AppBundle/Controller/ApiController.php"
     type:     annotation
     prefix:   /api/v1
+    schemes: [https]
 
 api_v1_admin:
     resource: "@AppBundle/Controller/AdminApiController.php"
     type:     annotation
     prefix:   /api/v1/admin
+    schemes: [https]
 
 
 easy_admin_bundle:
     resource: "@AppBundle/Controller/AdminController.php"
     type:     annotation
     prefix:   /admin
+    schemes: [https]

--- a/app/config/routing_dev.yml
+++ b/app/config/routing_dev.yml
@@ -12,3 +12,4 @@ _errors:
 
 _main:
     resource: routing.yml
+    schemes: [http]


### PR DESCRIPTION
Le site de preprod est accessible en https avec un certificat valide, donc ceci devrait marcher.
Je n'ai pas pu tester trop en profondeur en local, https n'étant pas (facilement) utilisable. 

Lors de la release, faire une vérification que les routes d'api fonctionnent bien, et génère bien les urls en https 

fixes #40 
(in theory)
