### PR TITLE
fix migration for mysql 5.5; force mysql version in docker

### DIFF
--- a/app/DoctrineMigrations/Version20160930142225.php
+++ b/app/DoctrineMigrations/Version20160930142225.php
@@ -20,7 +20,10 @@ class Version20160930142225 extends AbstractMigration
 
         $this->addSql('ALTER TABLE filter RENAME criterion');
         $this->addSql('ALTER TABLE recommendation_filter RENAME recommendation_criterion');
+        $this->addSql('ALTER TABLE recommendation_criterion DROP FOREIGN KEY FK_74D6F1E7D395B25E');
         $this->addSql('ALTER TABLE recommendation_criterion CHANGE filter_id criterion_id INT NOT NULL');
+        $this->addSql('ALTER TABLE recommendation_criterion ADD CONSTRAINT FK_74D6F1E7D395B25E FOREIGN KEY (criterion_id) REFERENCES criterion (id) ON DELETE CASCADE');
+
     }
 
     /**
@@ -33,6 +36,8 @@ class Version20160930142225 extends AbstractMigration
 
         $this->addSql('ALTER TABLE criterion RENAME filter');
         $this->addSql('ALTER TABLE recommendation_criterion RENAME recommendation_filter');
+        $this->addSql('ALTER TABLE recommendation_filter DROP FOREIGN KEY FK_74D6F1E7D395B25E');
         $this->addSql('ALTER TABLE recommendation_filter CHANGE criterion_id filter_id INT NOT NULL');
+        $this->addSql('ALTER TABLE recommendation_filter ADD CONSTRAINT FK_74D6F1E7D395B25E FOREIGN KEY (filter_id) REFERENCES filter (id) ON DELETE CASCADE');
     }
 }

--- a/docker/mysql/Dockerfile
+++ b/docker/mysql/Dockerfile
@@ -1,2 +1,1 @@
-FROM mysql:latest
-
+FROM mysql:5.5


### PR DESCRIPTION
@lilobase : corrige la migration fautive (j'ai déjà executé les requêtes correspondantes en preprod), et force la version de mysql sur docker à celle de clever-cloud
