### PR TITLE
remove error-generating index renaming

### DIFF
--- a/app/DoctrineMigrations/Version20160930145820.php
+++ b/app/DoctrineMigrations/Version20160930145820.php
@@ -19,8 +19,6 @@ class Version20160930145820 extends AbstractMigration
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('ALTER TABLE recommendation CHANGE contributor_id contributor_id INT NOT NULL');
-        $this->addSql('ALTER TABLE recommendation_criterion RENAME INDEX idx_74d6f1e7d173940b TO IDX_7EC3453D173940B');
-        $this->addSql('ALTER TABLE recommendation_criterion RENAME INDEX idx_74d6f1e7d395b25e TO IDX_7EC345397766307');
     }
 
     /**
@@ -32,7 +30,5 @@ class Version20160930145820 extends AbstractMigration
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('ALTER TABLE recommendation CHANGE contributor_id contributor_id INT DEFAULT NULL');
-        $this->addSql('ALTER TABLE recommendation_criterion RENAME INDEX idx_7ec3453d173940b TO IDX_74D6F1E7D173940B');
-        $this->addSql('ALTER TABLE recommendation_criterion RENAME INDEX idx_7ec345397766307 TO IDX_74D6F1E7D395B25E');
     }
 }


### PR DESCRIPTION
La migration en preprod a été fixée
la syntax RENAME INDEX est spécifique a mysql 5.7 (et a été généré par le migration bundle qui s'est basé sur la version locale de mysql). Je vois pas trop l'intérêt du renommage de l'index en passant ....
