### PR TITLE
hopefully fix https infinite redirect

### DIFF
--- a/web/app_itg.php
+++ b/web/app_itg.php
@@ -25,6 +25,7 @@ $kernel->loadClassCache();
 // When using the HttpCache, you need to call the method in your front controller instead of relying on the configuration parameter
 //Request::enableHttpMethodParameterOverride();
 $request = Request::createFromGlobals();
+Request::setTrustedProxies([$request->server->get('REMOTE_ADDR')]);
 $response = $kernel->handle($request);
 $response->send();
 $kernel->terminate($request, $response);


### PR DESCRIPTION
https termination is probably on the load balancer  - force symfony to trust its headers.

CF http://stackoverflow.com/questions/26619695/symfony2-infinite-redirect-loop-with-schemes-routing-setting
