### PR TITLE
Fix/matching contexts/return empty when empty

### DIFF
--- a/src/AppBundle/Controller/Api/GetMatchingContextsAction.php
+++ b/src/AppBundle/Controller/Api/GetMatchingContextsAction.php
@@ -33,7 +33,7 @@ class GetMatchingContextsAction extends BaseAction
         }
         $matchingContexts = $this->repository->findAllPublicMatchingContext($contributors);
 
-        if (!$matchingContexts) {
+        if (!is_array($matchingContexts)) {
             throw new NotFoundHttpException('No matching contexts exists');
         }
 


### PR DESCRIPTION
Currently, if we asked for a list of matching-contexts and filter by contributors and the list is empty (subscribed contributors don't exist anymore or don't have any currently published notice), API gives a 404. 

This replaces this specific case with an empty `[]` response. 
