### PR TITLE
perf: avoid loading all subscriptions entities for each Contributor

### DIFF
--- a/app/config/easyadmin.yml
+++ b/app/config/easyadmin.yml
@@ -169,7 +169,7 @@ easy_admin:
                     - id
                     - name
                     - intro
-                    - { property : 'TotalActiveSubscriptions', label: 'Active Subscribers' }
+                    - { property : 'ActiveSubscriptionsCount', label: 'Active Subscribers' }
                     - enabled
             form:
                 fields:

--- a/src/AppBundle/Controller/Api/GetContributors.http
+++ b/src/AppBundle/Controller/Api/GetContributors.http
@@ -1,0 +1,5 @@
+GET http://localhost:8088/api/v3/contributors
+Content-Type: application/json
+
+
+###

--- a/src/AppBundle/Entity/Contributor.php
+++ b/src/AppBundle/Entity/Contributor.php
@@ -69,6 +69,8 @@ class Contributor implements ImageUploadable
      */
     private $subscriptions;
 
+    private $activeSubscriptionsCount = 0;
+
     /**
      * @var int
      *
@@ -246,21 +248,11 @@ class Contributor implements ImageUploadable
     }
 
     /*
-     * @return Subscription[]
-     */
-    public function getActiveSubscriptions(): Collection
-    {
-        return $this->subscriptions->filter(function (Subscription $subscription) {
-          return $subscription->isActive();
-        });
-    }
-
-    /**
      * @return int
      */
-    public function getTotalActiveSubscriptions(): int
+    public function getActiveSubscriptionsCount(): int
     {
-      return count($this->getActiveSubscriptions());
+        return $this->activeSubscriptionsCount;
     }
 
     /**
@@ -277,5 +269,14 @@ class Contributor implements ImageUploadable
     public function setEnabled($enabled)
     {
         $this->enabled = $enabled;
+    }
+
+    /**
+     * ⚠ Should not be used outside of repo
+     * @param int $activeSubscriptionsCount
+     */
+    public function setActiveSubscriptionsCount(int $activeSubscriptionsCount): void
+    {
+      $this->activeSubscriptionsCount = $activeSubscriptionsCount;
     }
 }

--- a/src/AppBundle/Entity/Subscription.php
+++ b/src/AppBundle/Entity/Subscription.php
@@ -101,4 +101,9 @@ class Subscription
       $this->updated->diff($now, TRUE)->days < self::DAYS_TO_BE_CONSIDERED_ACTIVE
     );
   }
+
+  public static function getFreshnessDate(): DateTime
+  {
+    return new DateTime('-'.self::DAYS_TO_BE_CONSIDERED_ACTIVE.'days');
+  }
 }

--- a/src/AppBundle/Repository/ContributorRepository.php
+++ b/src/AppBundle/Repository/ContributorRepository.php
@@ -3,9 +3,13 @@
 namespace AppBundle\Repository;
 
 use AppBundle\Entity\Contributor;
+use AppBundle\Entity\Subscription;
 use AppBundle\Helper\NoticeVisibility;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\Query\Expr\Join;
+use Doctrine\ORM\QueryBuilder;
+use function Doctrine\ORM\QueryBuilder;
 
 class ContributorRepository extends BaseRepository
 {
@@ -19,6 +23,15 @@ class ContributorRepository extends BaseRepository
         $this->noticeRepository = $noticeRepository;
     }
 
+    public static function addActiveSubscriptionsCount(QueryBuilder $queryBuilder)
+    {
+      return $queryBuilder
+        ->addSelect('count(s.extension) as activeSubscriptions')
+        ->leftJoin('c.subscriptions', 's', Join::WITH, 's.created >= :freshnessDate OR s.updated >= :freshnessDate')
+        ->groupBy('c.id')
+        ->setParameter('freshnessDate', Subscription::getFreshnessDate());
+    }
+
     public function getAllEnabledWithAtLeastOneContribution()
     {
         $activeContributorsQuery = $this->noticeRepository->repository->createQueryBuilder('n')
@@ -26,11 +39,21 @@ class ContributorRepository extends BaseRepository
             ->where('n.visibility = :visibility');
 
         $mainQuery = $this->repository->createQueryBuilder('c');
-        return $mainQuery
+        $mainQuery = $mainQuery
             ->where('c.enabled = true')
             ->andWhere($mainQuery->expr()->in('c.id', $activeContributorsQuery->getDQL()))
-            ->setParameter('visibility', NoticeVisibility::PUBLIC_VISIBILITY())
-            ->getQuery()->execute();
+            ->setParameter('visibility', NoticeVisibility::PUBLIC_VISIBILITY());
+
+        $resultsWithActiveSubscriptionsCount = self::addActiveSubscriptionsCount($mainQuery)
+          ->getQuery()
+          ->getResult();
+
+        return array_map(function ($result) {
+            /** @var Contributor $contributor */
+            $contributor = $result[0];
+            $contributor->setActiveSubscriptionsCount($result['activeSubscriptions']);
+            return $contributor;
+        }, $resultsWithActiveSubscriptionsCount);
     }
 
     /**
@@ -44,7 +67,9 @@ class ContributorRepository extends BaseRepository
             ->andwhere('c.enabled = true')
             ->setParameter('id', $id);
 
-        return $queryBuilder->getQuery()->getOneOrNullResult();
+        return self::addActiveSubscriptionsCount($queryBuilder)
+          ->getQuery()
+          ->getOneOrNullResult();
     }
 
     /**

--- a/src/AppBundle/Serializer/ContributorNormalizer.php
+++ b/src/AppBundle/Serializer/ContributorNormalizer.php
@@ -64,7 +64,7 @@ class ContributorNormalizer implements NormalizerInterface, NormalizerAwareInter
             'intro' => $object->getIntro() ? DataConverter::convertFullIntro($object->getIntro()) : null,
             'name' => $object->getName(),
             'ratings' => [
-                'subscribes' => $object->getTotalActiveSubscriptions(),
+                'subscribes' => $object->getActiveSubscriptionsCount(),
             ],
         ];
     }


### PR DESCRIPTION
We’re getting 

```
 2020-02-03T11:01:53+01:00 [:error] [pid 1222:tid 140318673360640] [client 46.252.181.159:50006] 
FastCGI: server "/var/www/php5-fpm/php5.external" stderr: PHP message: [2020-02-03 10:01:52] request.
CRITICAL: Uncaught PHP Exception Symfony\\Component\\Debug\\Exception\\OutOfMemoryException: "Error: Allowed memory size of 67108864 bytes exhausted (tried to allocate 20480 bytes)" 
at /home/bas/app_e440b605-7424-41a5-9e94-d1bf9d3bd164/vendor/doctrine/orm/lib/Doctrine/ORM/UnitOfWork.php
```

This puts active contributors on the database side to avoid loading every subscription entity for each contrbutor.

I tried to do the same for `Contributor->getTheirMostLikedOrDisplayedNotice` but I ended up with a 4-tables query that was taking 5-7 seconds on staging :-/ so I gave up

Made me see how CQRS could be nice :-)