### PR TITLE
fix: use array_map on true array instead of Doctrine’s Collection’s map

### DIFF
--- a/src/AppBundle/Serializer/ContributorNormalizer.php
+++ b/src/AppBundle/Serializer/ContributorNormalizer.php
@@ -68,9 +68,9 @@ class ContributorNormalizer implements NormalizerInterface, NormalizerAwareInter
             'ratings' => [
                 'subscribes' => $object->getActiveSubscriptionsCount(),
             ],
-            'noticesUrls' => $object->getPublicNotices()->map(function (Notice $notice) {
+            'noticesUrls' => array_values($object->getPublicNotices()->map(function (Notice $notice) {
                 return $this->noticeUrlGenerator->generate($notice);
-            })->toArray(),
+            })->toArray()),
         ];
     }
 


### PR DESCRIPTION
(hopefully) resolves #224 

@lutangar I can see that `toArray` on Doctrine’s `Collection` returns an associative `array<TKey,T>`

```php
/**
     * Gets a native PHP array representation of the collection.
     *
     * @return array
     *
     * @psalm-return array<TKey,T>
     */
    public function toArray();
```

I applied an `array_values` … Let’s try it on staging