### PR TITLE
feat(api): add notices endpoint

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,7 +105,7 @@ While the prerequisites above must be satisfied prior to having your pull reques
 
 ### PHP Styleguide
 
-All JavaScript must adhere to [PHP The Right Way](https://phptherightway.com/#code_style_guide) code style.
+All JavaScript must adhere to [PHP The Right Way](https://phptherightway.com/#code_style_guide) code style.
 
 We also use [PHP CS Fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer) to enforce @Symfony code style.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,7 +105,7 @@ While the prerequisites above must be satisfied prior to having your pull reques
 
 ### PHP Styleguide
 
-All JavaScript must adhere to [PHP The Right Way](https://phptherightway.com/#code_style_guide) code style.
+All PHP code must adhere to [PHP The Right Way](https://phptherightway.com/#code_style_guide) code style.
 
 We also use [PHP CS Fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer) to enforce @Symfony code style.
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3,7 +3,7 @@
   "info" : {
     "title" : "DisMoi API",
     "description": "API to fetch contributors, notices and matching contexts of dismoi.io",
-    "version" : "3.3.0",
+    "version" : "3.4.0",
     "contact" : { }
   },
   "paths" : {
@@ -63,6 +63,34 @@
         }
       }
     },
+    "/notices" : {
+      "get" : {
+        "summary" : "Retrieve notices’ list.",
+        "tags" : [ "Notices" ],
+        "parameters" : [ {
+          "name" : "contributor",
+          "in" : "query",
+          "required" : false,
+          "description" : "Only include notices from one of this contributor. Include all if missing.",
+          "example": 6,
+          "schema" : {
+              "type" : "integer"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Notices list",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/NoticeEntityWithContributorId"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/notices/{noticeId}" : {
       "get" : {
         "summary" : "Retrieve a Notice by its id.",
@@ -83,7 +111,7 @@
             "content" : {
               "application/json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/NoticeEntity"
+                  "$ref" : "#/components/schemas/NoticeEntityWithContributorDetails"
                 }
               }
             }
@@ -354,8 +382,55 @@
         },
         "required" : [ "url" ]
       },
-      "NoticeEntity" : {
+      "NoticeEntityWithContributorId": {
         "title" : "Notice Entity",
+        "example" : {
+          "id" : 6,
+          "contributorId" : 42,
+          "message" : "<p>D'après le comparatif Cero1net des smartphones à moins de 200 €, le smartphone Road Kiiwi obtient une note de 6,6/10. Parmi les meilleures alternatives, le Azer Aquoz Z630 obtient une note de 8.1/10 : il a notamment une bien meilleure durée de batterie en navigation web : 15h56 min contre 6h47 min. Et il est vendu 40 € moins cher.</p>",
+          "visibility" : "public",
+          "exampleUrl": "http://dismoi.io",
+          "ratings" : {
+            "likes" : 7,
+            "dislikes" : 2
+          },
+          "created" : "2018-01-25",
+          "modified" : "2019-03-30"
+        },
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "integer"
+          },
+          "message" : {
+            "type" : "string"
+          },
+          "example":  {
+            "type" : "string"
+          },
+          "ratings" : {
+            "$ref" : "#/components/schemas/ratings"
+          },
+          "visibility" : {
+            "type" : "string",
+            "enum" : [ "public", "private", "archived" ]
+          },
+          "created" : {
+            "type" : "string",
+            "format" : "date"
+          },
+          "modified" : {
+            "type" : "string",
+            "format" : "date"
+          },
+          "contributorId" : {
+            "type" : "integer"
+          }
+        },
+        "required" : [ "contributor", "created", "id", "message", "ratings", "visibility" ]
+      },
+      "NoticeEntityWithContributorDetails": {
+        "title" : "Notice Entity with Contributor Details",
         "example" : {
           "contributor" : {
             "id" : 42,
@@ -376,7 +451,7 @@
           },
           "created" : "2018-01-25",
           "id" : 6,
-          "intention" : "alternative",
+          "exampleUrl" : "https://dismoi.io",
           "message" : "<p>D'après le comparatif Cero1net des smartphones à moins de 200 €, le smartphone Road Kiiwi obtient une note de 6,6/10. Parmi les meilleures alternatives, le Azer Aquoz Z630 obtient une note de 8.1/10 : il a notamment une bien meilleure durée de batterie en navigation web : 15h56 min contre 6h47 min. Et il est vendu 40 € moins cher.</p>",
           "modified" : "2019-03-30",
           "ratings" : {
@@ -397,8 +472,8 @@
           "id" : {
             "type" : "integer"
           },
-          "intention" : {
-            "$ref" : "#/components/schemas/intention"
+          "exampleUrl" : {
+            "type" : "string"
           },
           "message" : {
             "type" : "string"
@@ -415,7 +490,7 @@
             "enum" : [ "public", "private", "archived" ]
           }
         },
-        "required" : [ "contributor", "created", "id", "intention", "message", "ratings", "visibility" ]
+        "required" : [ "contributor", "created", "id", "message", "ratings", "visibility" ]
       },
       "ratings" : {
         "title" : "ratings",
@@ -433,12 +508,6 @@
           }
         },
         "required" : [ "likes", "dislikes" ]
-      },
-      "intention" : {
-        "title" : "intention",
-        "example" : "approval",
-        "type" : "string",
-        "enum" : [ "approval", "disapproval", "alternative", "information", "other" ]
       },
       "ContributorEntity" : {
         "title" : "Contributor Entity",
@@ -472,7 +541,7 @@
           "noticesUrls": [
             "https://staging-notices.bulles.fr/api/v3/notices/21",
             "https://staging-notices.bulles.fr/api/v3/notices/42",
-            "https://staging-notices.bulles.fr/api/v3/notices/84",
+            "https://staging-notices.bulles.fr/api/v3/notices/84"
           ]
         },
         "type" : "object",

--- a/src/AppBundle/Controller/Api/BaseAction.php
+++ b/src/AppBundle/Controller/Api/BaseAction.php
@@ -14,15 +14,17 @@ abstract class BaseAction
         $this->serializer = $serializer;
     }
 
-    protected function createResponse($content, $status = 200, $headers = [])
+    protected function createResponse($content, $serializerOptions = [])
     {
-        $json = $this->serialize($content);
+        $status = 200;
+        $headers = [];
+        $json = $this->serialize($content, $serializerOptions);
 
         return new JsonResponse($json, $status, $headers, true);
     }
 
-    protected function serialize($content)
+    protected function serialize($content, $serializerOptions = [])
     {
-        return $this->serializer->serialize($content, 'json', ['groups' => ['v3:list']]);
+        return $this->serializer->serialize($content, 'json', $serializerOptions);
     }
 }

--- a/src/AppBundle/Controller/Api/GetNoticesAction.php
+++ b/src/AppBundle/Controller/Api/GetNoticesAction.php
@@ -10,30 +10,37 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Serializer\SerializerInterface;
 
-class GetNoticeAction extends BaseAction
+class GetNoticesAction extends BaseAction
 {
-    protected $repository;
+    /**
+     * @var NoticeRepository
+     */
+    private $repository;
 
     public function __construct(SerializerInterface $serializer, NoticeRepository $repository)
     {
         parent::__construct($serializer);
-
         $this->repository = $repository;
     }
 
     /**
-     * @Route("/notices/{id}")
+     * @Route("/notices")
      * @Method("GET")
      */
     public function __invoke(Request $request)
     {
-        $id = $request->get('id', null);
-        $notice = $this->repository->getOne($id);
+        $contributorId = $request->get('contributor', null);
 
-        if (!$notice) {
-            throw new NotFoundHttpException('Notice not found.');
+        if ($contributorId) {
+            $notices = $this->repository->getByContributor($contributorId);
+        } else {
+            $notices = $this->repository->getAll();
         }
 
-        return $this->createResponse($notice, [NormalizerOptions::INCLUDE_CONTRIBUTORS_DETAILS => true]);
+        if (!is_array($notices)) {
+            throw new NotFoundHttpException('No notices found');
+        }
+
+        return $this->createResponse($notices, [NormalizerOptions::INCLUDE_CONTRIBUTORS_DETAILS => false]);
     }
 }

--- a/src/AppBundle/Controller/Api/PostContributorRatingAction.php
+++ b/src/AppBundle/Controller/Api/PostContributorRatingAction.php
@@ -10,7 +10,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Serializer\SerializerInterface;
 
-// TODO: Remove when not used anymore
+// TODO: Remove when not used anymore
 class PostContributorRatingAction extends BaseAction
 {
     protected $contributorRepository;

--- a/src/AppBundle/Entity/Notice.php
+++ b/src/AppBundle/Entity/Notice.php
@@ -349,4 +349,18 @@ class Notice
     {
         $this->excludeUrlRegex = $excludeUrlRegex;
     }
+
+    public function getExampleUrl(): ?string
+    {
+        $first = $this->getMatchingContexts()
+            ->filter(function (MatchingContext $mc) {
+                return (bool) $mc->getExampleUrl();
+            })
+            ->first();
+        if ($first) {
+            return $first->getExampleUrl();
+        } else {
+            return null;
+        }
+    }
 }

--- a/src/AppBundle/Repository/NoticeRepository.php
+++ b/src/AppBundle/Repository/NoticeRepository.php
@@ -16,16 +16,37 @@ class NoticeRepository extends BaseRepository
      */
     public function getOne($id)
     {
+        return $this->createQueryForPublicNotices()
+            ->where('n.id = :id')
+            ->setParameter('id', $id)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+
+    public function getAll()
+    {
+        return $this->createQueryForPublicNotices()
+            ->getQuery()
+            ->getResult();
+    }
+
+    public function getByContributor($contributorId)
+    {
+        return $this->createQueryForPublicNotices()
+            ->where('n.contributor = :contributorId')
+            ->setParameter('contributorId', $contributorId)
+            ->getQuery()
+            ->getResult();
+    }
+
+    private function createQueryForPublicNotices()
+    {
         $queryBuilder = $this->repository->createQueryBuilder('n')
             ->select('n,c')
             ->leftJoin('n.contributor', 'c')
-            ->where('n.id = :id')
-            ->andWhere('c.enabled = true')
-            ->setParameter('id', $id);
+            ->andWhere('c.enabled = true');
 
-        return self::addNoticeExpirationLogic($queryBuilder)
-            ->getQuery()->getOneOrNullResult()
-        ;
+        return self::addNoticeExpirationLogic($queryBuilder);
     }
 
     /**

--- a/src/AppBundle/Serializer/NormalizerOptions.php
+++ b/src/AppBundle/Serializer/NormalizerOptions.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace AppBundle\Serializer;
+
+final class NormalizerOptions
+{
+    const INCLUDE_CONTRIBUTORS_DETAILS = 'INCLUDE_CONTRIBUTORS_DETAILS';
+}

--- a/src/AppBundle/Serializer/NoticeNormalizer.php
+++ b/src/AppBundle/Serializer/NoticeNormalizer.php
@@ -45,26 +45,33 @@ class NoticeNormalizer implements NormalizerInterface, NormalizerAwareInterface
         return $data instanceof Notice;
     }
 
-    public function normalize($object, $format = null, array $context = []): array
+    public function normalize($notice, $format = null, array $context = []): array
     {
-        if (!($object instanceof Notice)) {
+        if (!($notice instanceof Notice)) {
             throw new InvalidArgumentException();
         }
 
-        return [
-            'contributor' => $this->normalizer->normalize($object->getContributor(), $format, $context),
-            'created' => $this->formatDateTime($object->getCreated()),
-            'id' => $object->getId(),
-            'url' => $this->noticeUrlGenerator->generate($object),
-            'intention' => $object->getIntention()->getValue(),
-            'message' => $this->messagePresenter->present($object->getMessage()),
-            'modified' => $this->formatDateTime($object->getUpdated()),
+        $base = [
+            'id' => $notice->getId(),
+            'url' => $this->noticeUrlGenerator->generate($notice),
+            'message' => $this->messagePresenter->present($notice->getMessage()),
+            'visibility' => $notice->getVisibility()->getValue(),
+            'example' => $notice->getExampleUrl(),
             'ratings' => [
-                'likes' => $object->getLikedRatingCount(),
-                'dislikes' => $object->getDislikedRatingCount(),
+                'likes' => $notice->getLikedRatingCount(),
+                'dislikes' => $notice->getDislikedRatingCount(),
             ],
-            'visibility' => $object->getVisibility()->getValue(),
+            'created' => $this->formatDateTime($notice->getCreated()),
+            'modified' => $this->formatDateTime($notice->getUpdated()),
         ];
+
+        if ($context[NormalizerOptions::INCLUDE_CONTRIBUTORS_DETAILS]) {
+            $base['contributor'] = $this->normalizer->normalize($notice->getContributor(), $format, $context);
+        } else {
+            $base['contributorId'] = $notice->getContributor()->getId();
+        }
+
+        return $base;
     }
 
     protected function formatDateTime(\DateTime $datetime): string

--- a/web/js/regex_validator.js
+++ b/web/js/regex_validator.js
@@ -156,7 +156,7 @@
         const domainNames = getAllRelatedDomains(matchingContextField);
 
         const status = regexField.value ? validateUrlRegexp(
-            domainNames.length ? domainNames.map(injectRegexToDomain(regexField.value)) : [regexField.value],
+            domainNames.length ? domainNames.map(injectRegexToDomain(regexField.value)) : [regexField.value],
             matchingContextExcludeField.value,
             noticeExcludeField.value,
             exampleField.value,


### PR DESCRIPTION
Add `/notices` endpoint to get the list of all publicly visible notices.

Can be filtered with get parameter `?contributor=42`

Comparing to existing `/notices/{id}` :
- replaced `contributor` (with details) by `contributorId` (id only)
- removed `intention` in response
- add `exampleUrl`