### PR TITLE
feat(domains): proto-domains

### DIFF
--- a/app/DoctrineMigrations/Version20200716152334.php
+++ b/app/DoctrineMigrations/Version20200716152334.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20200716152334 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $this->abortIf('mysql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE domain_name ADD path VARCHAR(255) NOT NULL;');
+        $this->addSql('UPDATE domain_name SET path = :path', ['path' => '/']);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->abortIf('mysql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE domain_name DROP COLUMN path');
+    }
+}

--- a/app/Resources/translations/messages.fr.yml
+++ b/app/Resources/translations/messages.fr.yml
@@ -70,6 +70,7 @@ restrictedContexts:
 domains:
   id: Id
   name: Nom du domaine
+  path: Chemin
   sets: Groupes de domaines liés
   sets.nb: Nb de groupes de domaines liés
   matchingContexts: Pages cibles liées

--- a/app/config/easyadmin.yml
+++ b/app/config/easyadmin.yml
@@ -194,17 +194,18 @@ easy_admin:
                 actions: ['show']
                 sort: ['name', 'ASC']
                 fields:
-                    - { property: name, label: domains.name }
+                    - { property: prettyName, label: domains.name }
                     - { property: sets, label: domains.sets.nb }
                     - { property: matchingContexts, label: domains.matchingContexts.nb }
             form:
                 fields:
                     - { property: name, label: domains.name }
+                    - { property: path, label: domains.path }
             show:
                 max_results: 100
                 fields:
                     - { property: id, label: domains.id }
-                    - { property: name, label: domains.name }
+                    - { property: prettyName, label: domains.name }
                     - { property: sets, label: domains.sets }
                     # ugly but https://github.com/EasyCorp/EasyAdminBundle/issues/1108
                     - {

--- a/src/AppBundle/Entity/DomainName.php
+++ b/src/AppBundle/Entity/DomainName.php
@@ -37,6 +37,13 @@ class DomainName
      */
     private $name;
 
+    /** @var string
+     *
+     * @ORM\Column(name="path", type="string", length=255, nullable=false)
+     * @Assert\Regex("/^\/([\w\d]+[-_%.\/\w\d]*)?$/")
+     */
+    private $path;
+
     /**
      * @var Collection
      *
@@ -66,13 +73,14 @@ class DomainName
     public function __construct(string $name = '')
     {
         $this->name = $name;
+        $this->path = '/';
         $this->matchingContexts = new ArrayCollection();
         $this->sets = new ArrayCollection();
     }
 
     public function __toString(): string
     {
-        return $this->name;
+        return $this->getPrettyName();
     }
 
     /**
@@ -91,6 +99,16 @@ class DomainName
     public function getName(): string
     {
         return $this->name;
+    }
+
+    public function getPrettyName(): string
+    {
+        return $this->name.('/' === $this->path ? '' : $this->path);
+    }
+
+    public function getFullName(): string
+    {
+        return $this->name.$this->path;
     }
 
     public function getMatchingContexts(): Collection
@@ -118,5 +136,17 @@ class DomainName
         return array_map(function (MatchingContext $mc) {
             return $mc->getNotice();
         }, $this->getMatchingContexts()->toArray());
+    }
+
+    public function getPath(): ?string
+    {
+        return $this->path;
+    }
+
+    public function setPath(?string $path): DomainName
+    {
+        $this->path = $path;
+
+        return $this;
     }
 }

--- a/src/AppBundle/Entity/MatchingContext.php
+++ b/src/AppBundle/Entity/MatchingContext.php
@@ -12,7 +12,9 @@ use Symfony\Component\Validator\Constraints as Assert;
 function flatten(array $array)
 {
     $return = [];
-    array_walk_recursive($array, function ($a) use (&$return) { $return[] = $a; });
+    array_walk_recursive($array, function ($a) use (&$return) {
+        $return[] = $a;
+    });
 
     return $return;
 }
@@ -189,10 +191,11 @@ class MatchingContext
             return $this->urlRegex;
         }
 
-        return '('.join('|',
-          array_map(function (DomainName $dn) use ($escaper) {
-              return escape($dn->getName(), $escaper);
-          }, $domains)
+        return '('.implode(
+            '|',
+            array_map(static function (DomainName $dn) use ($escaper) {
+                return escape($dn->getFullName(), $escaper);
+            }, $domains)
         ).')'.$this->urlRegex;
     }
 

--- a/src/AppBundle/Form/MatchingContextType.php
+++ b/src/AppBundle/Form/MatchingContextType.php
@@ -33,7 +33,7 @@ class MatchingContextType extends AbstractType
                     return [
                         'data-domains' => join(',', array_map(
                             function (DomainName $domainName) {
-                                return $domainName->getName();
+                                return $domainName->getPrettyName();
                             },
                             $domainsSet->getDomains()->toArray()
                         )),

--- a/tests/AppBundle/Entity/MatchingContextTest.php
+++ b/tests/AppBundle/Entity/MatchingContextTest.php
@@ -23,10 +23,10 @@ class MatchingContextTest extends FixtureAwareWebTestCase
         /** @var MatchingContext $mc */
         $mc = static::$referenceRepository->getReference('mc_with_domain_name');
         $regex = $mc->getFullUrlRegex($escaper);
-        $this->assertEquals('(duckduckgo.com|www.bing.com|www.google.fr|www.qwant.com|www.yahoo.com|first.domainname.fr|second.domainname.fr)'.$mc->getUrlRegex(), $regex);
+        $this->assertEquals('(duckduckgo.com/|www.bing.com/|www.google.fr/|www.qwant.com/|www.yahoo.com/|first.domainname.fr/|second.domainname.fr/)'.$mc->getUrlRegex(), $regex);
 
         $regex = $mc->getFullUrlRegex();
-        $this->assertEquals('(duckduckgo.com|www.bing.com|www.google.fr|www.qwant.com|www.yahoo.com|first.domainname.fr|second.domainname.fr)'.$mc->getUrlRegex(), $regex);
+        $this->assertEquals('(duckduckgo.com/|www.bing.com/|www.google.fr/|www.qwant.com/|www.yahoo.com/|first.domainname.fr/|second.domainname.fr/)'.$mc->getUrlRegex(), $regex);
 
         /** @var MatchingContext $mc */
         $mc = static::$referenceRepository->getReference('mc_without_domain_name');

--- a/tests/e2e/GetMatchingContextsTest.php
+++ b/tests/e2e/GetMatchingContextsTest.php
@@ -7,7 +7,7 @@ class GetMatchingContextsTest extends BaseApiE2eTestCase
     public function getMatchingContextsData()
     {
         return [
-            [null, 6, ['http://site-ecologique.fr', 'http://random-site.fr', 'http://site-ecologique-et-politique.fr', 'http://expired.fr', "(duckduckgo\.com|www\.bing\.com|www\.google\.fr|www\.qwant\.com|www\.yahoo\.com|first\.domainname\.fr|second\.domainname\.fr)/superexample", 'http://siteecologique.fr']],
+            [null, 6, ['http://site-ecologique.fr', 'http://random-site.fr', 'http://site-ecologique-et-politique.fr', 'http://expired.fr', "(duckduckgo\.com/|www\.bing\.com/|www\.google\.fr/|www\.qwant\.com/|www\.yahoo\.com/|first\.domainname\.fr/|second\.domainname\.fr/)/superexample", 'http://siteecologique.fr']],
             [['john_doe', 'contributor2'], 5, ['http://site-ecologique.fr', 'http://site-ecologique-et-politique.fr', 'http://random-site.fr', 'http://expired.fr', 'http://siteecologique.fr']],
             [['john_doe'], 3, ['http://site-ecologique.fr', 'http://random-site.fr', 'http://siteecologique.fr']],
             [['contributor2'], 2, ['http://site-ecologique-et-politique.fr', 'http://expired.fr']],


### PR DESCRIPTION
We need to be able to set up domains like this :

![image](https://user-images.githubusercontent.com/3037833/87758891-a2390f80-c80d-11ea-9ac3-ba9cc370b644.png)

But we still need to keep the real domain separated in order to handle https://github.com/dis-moi/extension/issues/277 later

So, I added a `path` field in the form :

![image](https://user-images.githubusercontent.com/3037833/87759446-9f8aea00-c80e-11ea-9e60-ba6b91e6ed50.png)

That is then used transparently in the rest of the admin :
![image](https://user-images.githubusercontent.com/3037833/87759855-38ba0080-c80f-11ea-90b3-a7d31e5b5799.png)

And in the `/matching-contexts` 

![image](https://user-images.githubusercontent.com/3037833/87760275-cdbcf980-c80f-11ea-8462-e6568e6e6ea1.png)
