### PR TITLE
feat: Set default notices sorting order to most recent first.

### DIFF
--- a/src/AppBundle/Repository/NoticeRepository.php
+++ b/src/AppBundle/Repository/NoticeRepository.php
@@ -43,7 +43,9 @@ class NoticeRepository extends BaseRepository
         $queryBuilder = $this->repository->createQueryBuilder($noticeAlias)
             ->select("$noticeAlias, $contributorAlias")
             ->leftJoin("$noticeAlias.contributor", $contributorAlias)
-            ->where("$contributorAlias.enabled = true");
+            ->where("$contributorAlias.enabled = true")
+            ->orderBy("$noticeAlias.created", 'DESC')
+        ;
 
         return self::addNoticeVisibilityLogic($queryBuilder, $noticeAlias);
     }


### PR DESCRIPTION
I thought it would be more convenient to sort it on the backend side.
What do you think ?

> More context https://trello.com/c/pu0ACSW2/538-la-liste-des-contributions-sur-chaque-profil-devrait-%C3%AAtre-de-la-plus-r%C3%A9cente-%C3%A0-la-plus-ancienne-et-non-linverse