### PR TITLE
fix: allow empty path in proto-fix/fix/allow_empty_path_in_proto_domains

### DIFF
--- a/app/DoctrineMigrations/Version20200727144305.php
+++ b/app/DoctrineMigrations/Version20200727144305.php
@@ -7,20 +7,21 @@ namespace Application\Migrations;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
 
-final class Version20200716152334 extends AbstractMigration
+final class Version20200727144305 extends AbstractMigration
 {
     public function up(Schema $schema): void
     {
         $this->abortIf('mysql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'mysql\'.');
 
-        $this->addSql('ALTER TABLE domain_name ADD path VARCHAR(255) NOT NULL;');
-        $this->addSql('UPDATE domain_name SET path = :path', ['path' => '/']);
+        $this->addSql('ALTER TABLE domain_name MODIFY path VARCHAR(255) NULL;');
+        $this->addSql('UPDATE domain_name SET path = :newPath where path = :existingPath', ['newPath' => null, 'existingPath' => '/']);
     }
 
     public function down(Schema $schema): void
     {
         $this->abortIf('mysql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'mysql\'.');
 
-        $this->addSql('ALTER TABLE domain_name DROP COLUMN path');
+        $this->addSql('UPDATE domain_name SET path = :newPath where path is null', ['newPath' => '/']);
+        $this->addSql('ALTER TABLE domain_name MODIFY path VARCHAR(255) NOT NULL;');
     }
 }

--- a/src/AppBundle/Entity/DomainName.php
+++ b/src/AppBundle/Entity/DomainName.php
@@ -39,7 +39,7 @@ class DomainName
 
     /** @var string
      *
-     * @ORM\Column(name="path", type="string", length=255, nullable=false)
+     * @ORM\Column(name="path", type="string", length=255, nullable=true)
      * @Assert\Regex("/^\/([\w\d]+[-_%.\/\w\d]*)?$/")
      */
     private $path;
@@ -103,7 +103,7 @@ class DomainName
 
     public function getPrettyName(): string
     {
-        return $this->name.('/' === $this->path ? '' : $this->path);
+        return $this->getFullName();
     }
 
     public function getFullName(): string


### PR DESCRIPTION
Because all matching-contexts are already set with a regex starting
with a slash