### PR TITLE
chore: remove matching context's deprecated domainName field

### DIFF
--- a/migrations/Version20201125112749.php
+++ b/migrations/Version20201125112749.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20201125112749 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $this->abortIf('mysql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE matching_context DROP domainName');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->abortIf('mysql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE matching_context ADD domainName VARCHAR(150) DEFAULT NULL');
+    }
+}

--- a/src/DataFixtures/MatchingContextFixtures.php
+++ b/src/DataFixtures/MatchingContextFixtures.php
@@ -65,7 +65,6 @@ class MatchingContextFixtures extends Fixture implements DependentFixtureInterfa
 
         $matchingContext = new MatchingContext();
         $matchingContext->setExampleUrl('https://www.domainname.fr/coucou/example');
-        $matchingContext->setDomainName('domainname.fr');
         $matchingContext->addDomainName($this->getReference('first_domain'));
         $matchingContext->addDomainName($this->getReference('second_domain'));
         $matchingContext->addDomainsSet($this->getReference('search_engines_domains_set'));

--- a/src/Entity/MatchingContext.php
+++ b/src/Entity/MatchingContext.php
@@ -59,15 +59,6 @@ class MatchingContext
     private $exampleUrl;
 
     /**
-     * @var string
-     *
-     * @ORM\Column(name="domainName", type="string", length=150, nullable=true)
-     *
-     * @Assert\Regex("/^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$/")
-     */
-    private $domainName;
-
-    /**
      * @var Collection
      *
      * @ORM\ManyToMany(targetEntity="DomainName", inversedBy="matchingContexts")
@@ -148,18 +139,6 @@ class MatchingContext
     public function getExampleUrl(): ?string
     {
         return $this->exampleUrl;
-    }
-
-    public function setDomainName(string $domainName = null): MatchingContext
-    {
-        $this->domainName = $domainName;
-
-        return $this;
-    }
-
-    public function getDomainName(): ?string
-    {
-        return $this->domainName;
     }
 
     /**`


### PR DESCRIPTION
It’s been months now that we use `DomainName` and `DomainsSet` entities instead of this legacy field …