### PR TITLE
fix(pinned-notices): Use notice normalizer for pinned notices

### DIFF
--- a/src/Controller/Api/GetContributorAction.php
+++ b/src/Controller/Api/GetContributorAction.php
@@ -3,6 +3,7 @@
 namespace App\Controller\Api;
 
 use App\Repository\ContributorRepository;
+use App\Serializer\NormalizerOptions;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Symfony\Component\HttpFoundation\Request;
@@ -33,6 +34,6 @@ class GetContributorAction extends BaseAction
             throw new NotFoundHttpException('Contributor not found.');
         }
 
-        return $this->createResponse($contributor);
+        return $this->createResponse($contributor, [NormalizerOptions::INCLUDE_CONTRIBUTORS_DETAILS => false]);
     }
 }

--- a/src/Controller/Api/GetContributorsAction.php
+++ b/src/Controller/Api/GetContributorsAction.php
@@ -3,6 +3,7 @@
 namespace App\Controller\Api;
 
 use App\Repository\ContributorRepository;
+use App\Serializer\NormalizerOptions;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -28,6 +29,6 @@ class GetContributorsAction extends BaseAction
             throw new NotFoundHttpException('No contributors exist');
         }
 
-        return $this->createResponse($contributors);
+        return $this->createResponse($contributors, [NormalizerOptions::INCLUDE_CONTRIBUTORS_DETAILS => false]);
     }
 }

--- a/src/Serializer/ContributorNormalizer.php
+++ b/src/Serializer/ContributorNormalizer.php
@@ -97,13 +97,6 @@ class ContributorNormalizer extends EntityWithImageNormalizer implements Normali
         $exampleNotice = $pinnedNotices->first() ?: $contributor->getPublicNotices()->first();
         $relays = $contributor->getPublicRelays();
 
-        $starred = $exampleNotice && $exampleNotice->getMatchingContexts() ? [/* Deprecated */
-            'exampleMatchingUrl' => $exampleNotice->getExampleMatchingUrl(),
-            'noticeId' => $exampleNotice->getId(),
-            'noticeUrl' => $this->noticeUrlGenerator->generate($exampleNotice),
-            'screenshot' => $this->getImageAbsoluteUrl($exampleNotice, 'screenshotFile'),
-        ] : null;
-
         return [
             'id' => $contributor->getId(),
             'name' => $contributor->getName(),
@@ -117,21 +110,9 @@ class ContributorNormalizer extends EntityWithImageNormalizer implements Normali
             'preview' => $this->getImageAbsoluteUrl($contributor, 'previewImageFile'),
             'contributions' => $contributor->getNoticesCount(),
             'contribution' => [
-                'example' => $starred, /* Deprecated */
-                'starred' => $starred, /* Deprecated */
-                'pinnedNotices' => $pinnedNotices->map(function (Notice $notice) {
-                    return [
-                        'sort' => $notice->getPinnedSort(),
-                        'id' => $notice->getId(),
-                        'url' => $this->noticeUrlGenerator->generate($notice),
-                        'strippedMessage' => $this->messagePresenter->strip($notice->getMessage()),
-                        'exampleMatchingUrl' => $notice->getExampleMatchingUrl(),
-                        'noticeId' => $notice->getId(), // @deprecated
-                        'noticeUrl' => $this->noticeUrlGenerator->generate($notice), // @deprecated
-                        'screenshot' => $this->getImageAbsoluteUrl($notice, 'screenshotFile'),
-                        'created' => NoticeNormalizer::formatDateTime($notice->getCreated()),
-                        'modified' => NoticeNormalizer::formatDateTime($notice->getUpdated()),
-                    ];
+                'example' => $this->normalizer->normalize($exampleNotice, $format, [NormalizerOptions::INCLUDE_CONTRIBUTORS_DETAILS => false]),
+                'pinnedNotices' => $pinnedNotices->map(function (Notice $notice) use ($format, $context) {
+                    return $this->normalizer->normalize($notice, $format, [NormalizerOptions::INCLUDE_CONTRIBUTORS_DETAILS => false]);
                 })->toArray(),
                 'numberOfPublishedNotices' => $contributor->getNoticesCount(),
             ],

--- a/tests/e2e/GetContributorsTest.php
+++ b/tests/e2e/GetContributorsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace App\Tests\e2e;
@@ -9,8 +10,7 @@ use App\Helper\CollectionHelper;
 use Doctrine\Common\Collections\ArrayCollection;
 
 /**
- * Class GetContributorsTest
- * @package App\Tests\e2e
+ * Class GetContributorsTest.
  */
 class GetContributorsTest extends BaseApiE2eTestCase
 {
@@ -62,7 +62,9 @@ class GetContributorsTest extends BaseApiE2eTestCase
 
         $fetchedContributors = $payload;
 
-        $fetchedFamousContributor = CollectionHelper::find(new ArrayCollection($fetchedContributors), static function ($contributor) { return $contributor['name'] === 'Famous Contributor'; });
+        $fetchedFamousContributor = CollectionHelper::find(new ArrayCollection($fetchedContributors), static function ($contributor) {
+            return 'Famous Contributor' === $contributor['name'];
+        });
         $fetchedFirstPinnedNotice = $fetchedFamousContributor['contribution']['pinnedNotices'][0];
 
         /** @var MatchingContext $mc */
@@ -71,7 +73,7 @@ class GetContributorsTest extends BaseApiE2eTestCase
         $notice = $this->referenceRepository->getReference('notice_liked_displayed');
 
         self::assertEquals($mc->getExampleUrl(), $fetchedFirstPinnedNotice['exampleMatchingUrl']);
-        self::assertEquals($notice->getId(), $fetchedFirstPinnedNotice['noticeId']);
-        self::assertStringEndsWith('/api/v3/notices/'.$notice->getId(), $fetchedFirstPinnedNotice['noticeUrl']);
+        self::assertEquals($notice->getId(), $fetchedFirstPinnedNotice['id']);
+        self::assertStringEndsWith('/api/v3/notices/'.$notice->getId(), $fetchedFirstPinnedNotice['url']);
     }
 }


### PR DESCRIPTION
BREAKING CHANGE: `noticeId` and `noticeUrl` fields are no longer exposed

This is a rework of  #296  to better work with :
https://github.com/dis-moi/extension/pull/739
