### PR TITLE
chore: Add `check-cs` command to run during the CI process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,9 @@ retest-no-deprecation:
 cs-fix:
 	$(COMPOSER) fix-cs
 
+cs-check:
+	$(COMPOSER) check-cs
+
 stop:
 	docker-compose stop
 

--- a/composer.json
+++ b/composer.json
@@ -77,6 +77,9 @@
         "fix-cs": [
             "php-cs-fixer fix"
         ],
+        "check-cs": [
+            "php-cs-fixer fix --dry-run --stop-on-violation"
+        ],
         "auto-scripts": {
             "cache:clear": "symfony-cmd",
             "assets:install %PUBLIC_DIR%": "symfony-cmd",


### PR DESCRIPTION
This might be considered as #326 follow-up. It was missing a way to run it on CI and to fail on a CS diff.

> More on `php-cs-fixer`usage:
> https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/2.18/doc/usage.rst#usage