### PR TITLE
Revert "fix(pinned-notices): Use notice normalizer for pinned notices"

### DIFF
--- a/src/Command/UpdateCaptainFactNoticesCommand.php
+++ b/src/Command/UpdateCaptainFactNoticesCommand.php
@@ -90,7 +90,7 @@ class UpdateCaptainFactNoticesCommand extends Command
 
         // Load Existing CaptainFact notices
         $this->loadExternalIdsOfNoticesForCaptainFactContributor();
-        
+
         // Load Youtube Domain Name
         $this->loadYoutubeDomainName();
 
@@ -174,10 +174,10 @@ class UpdateCaptainFactNoticesCommand extends Command
             return;
         }
     }
-    
+
     /**
      * Method loadYoutubeDomainName
-     * Load youtube domain name or create it if necessary
+     * Load youtube domain name or create it if necessary.
      */
     protected function loadYoutubeDomainName(): void
     {
@@ -189,14 +189,14 @@ class UpdateCaptainFactNoticesCommand extends Command
 
         if (!$this->youtubeDomainName) {
             $this->output->writeln('Youtube domain name needs to be created');
-            
+
             $this->youtubeDomainName = new DomainName();
             $this->youtubeDomainName->setName(self::YOUTUBE_DOMAIN_NAME);
-            
+
             $this
                 ->entityManager
                 ->persist($this->youtubeDomainName);
-            
+
             $this
                 ->entityManager
                 ->flush();
@@ -265,9 +265,9 @@ class UpdateCaptainFactNoticesCommand extends Command
     protected function isEntryEligible(array $entry, int &$sourcesCount): bool
     {
         // No need to go further is there isn't any associated video
-        if ($entry['youtubeId'] == '')
+        if ('' == $entry['youtubeId']) {
             return false;
-        
+        }
         $minSourcesCount = 8;
         $minScore = 1;
         $minSourcesCountWithMinScore = 5;

--- a/src/Controller/Api/GetContributorAction.php
+++ b/src/Controller/Api/GetContributorAction.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Controller\Api;
 
 use App\Repository\ContributorRepository;
-use App\Serializer\NormalizerOptions;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -40,6 +39,6 @@ class GetContributorAction extends BaseAction
             throw new NotFoundHttpException('Contributor not found.');
         }
 
-        return $this->createResponse($contributor, [NormalizerOptions::INCLUDE_CONTRIBUTORS_DETAILS => false]);
+        return $this->createResponse($contributor);
     }
 }

--- a/src/Controller/Api/GetContributorsAction.php
+++ b/src/Controller/Api/GetContributorsAction.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Controller\Api;
 
 use App\Repository\ContributorRepository;
-use App\Serializer\NormalizerOptions;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -35,6 +34,6 @@ class GetContributorsAction extends BaseAction
             throw new NotFoundHttpException('No contributors exist');
         }
 
-        return $this->createResponse($contributors, [NormalizerOptions::INCLUDE_CONTRIBUTORS_DETAILS => false]);
+        return $this->createResponse($contributors);
     }
 }

--- a/src/Serializer/ContributorNormalizer.php
+++ b/src/Serializer/ContributorNormalizer.php
@@ -99,7 +99,7 @@ class ContributorNormalizer extends EntityWithImageNormalizer implements Normali
         $exampleNotice = $pinnedNotices->first() ?: $contributor->getPublicNotices()->first();
         $relays = $contributor->getPublicRelays();
 
-        $starred = $exampleNotice && $exampleNotice->getMatchingContexts() ? [/* Deprecated */
+        $starred = $exampleNotice && $exampleNotice->getMatchingContexts() ? [// Deprecated
             'exampleMatchingUrl' => $exampleNotice->getExampleMatchingUrl(),
             'noticeId' => $exampleNotice->getId(),
             'noticeUrl' => $this->noticeUrlGenerator->generate($exampleNotice),
@@ -119,8 +119,8 @@ class ContributorNormalizer extends EntityWithImageNormalizer implements Normali
             'preview' => $this->getImageAbsoluteUrl($contributor, 'previewImageFile'),
             'contributions' => $contributor->getNoticesCount(),
             'contribution' => [
-                'example' => $starred, /* Deprecated */
-                'starred' => $starred, /* Deprecated */
+                'example' => $starred, // Deprecated
+                'starred' => $starred, // Deprecated
                 'pinnedNotices' => $pinnedNotices->map(function (Notice $notice) {
                     return [
                         'sort' => $notice->getPinnedSort(),

--- a/tests/e2e/GetContributorsTest.php
+++ b/tests/e2e/GetContributorsTest.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 namespace App\Tests\e2e;
@@ -10,7 +9,8 @@ use App\Helper\CollectionHelper;
 use Doctrine\Common\Collections\ArrayCollection;
 
 /**
- * Class GetContributorsTest.
+ * Class GetContributorsTest
+ * @package App\Tests\e2e
  */
 class GetContributorsTest extends BaseApiE2eTestCase
 {
@@ -62,9 +62,7 @@ class GetContributorsTest extends BaseApiE2eTestCase
 
         $fetchedContributors = $payload;
 
-        $fetchedFamousContributor = CollectionHelper::find(new ArrayCollection($fetchedContributors), static function ($contributor) {
-            return 'Famous Contributor' === $contributor['name'];
-        });
+        $fetchedFamousContributor = CollectionHelper::find(new ArrayCollection($fetchedContributors), static function ($contributor) { return $contributor['name'] === 'Famous Contributor'; });
         $fetchedFirstPinnedNotice = $fetchedFamousContributor['contribution']['pinnedNotices'][0];
 
         /** @var MatchingContext $mc */
@@ -73,7 +71,7 @@ class GetContributorsTest extends BaseApiE2eTestCase
         $notice = $this->referenceRepository->getReference('notice_liked_displayed');
 
         self::assertEquals($mc->getExampleUrl(), $fetchedFirstPinnedNotice['exampleMatchingUrl']);
-        self::assertEquals($notice->getId(), $fetchedFirstPinnedNotice['id']);
-        self::assertStringEndsWith('/api/v3/notices/'.$notice->getId(), $fetchedFirstPinnedNotice['url']);
+        self::assertEquals($notice->getId(), $fetchedFirstPinnedNotice['noticeId']);
+        self::assertStringEndsWith('/api/v3/notices/'.$notice->getId(), $fetchedFirstPinnedNotice['noticeUrl']);
     }
 }

--- a/tests/e2e/GetContributorsTest.php
+++ b/tests/e2e/GetContributorsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace App\Tests\e2e;
@@ -9,8 +10,7 @@ use App\Helper\CollectionHelper;
 use Doctrine\Common\Collections\ArrayCollection;
 
 /**
- * Class GetContributorsTest
- * @package App\Tests\e2e
+ * Class GetContributorsTest.
  */
 class GetContributorsTest extends BaseApiE2eTestCase
 {
@@ -62,7 +62,7 @@ class GetContributorsTest extends BaseApiE2eTestCase
 
         $fetchedContributors = $payload;
 
-        $fetchedFamousContributor = CollectionHelper::find(new ArrayCollection($fetchedContributors), static function ($contributor) { return $contributor['name'] === 'Famous Contributor'; });
+        $fetchedFamousContributor = CollectionHelper::find(new ArrayCollection($fetchedContributors), static function ($contributor) { return 'Famous Contributor' === $contributor['name']; });
         $fetchedFirstPinnedNotice = $fetchedFamousContributor['contribution']['pinnedNotices'][0];
 
         /** @var MatchingContext $mc */


### PR DESCRIPTION
Fixes #335 

This reverts commit bcd773c97fbaf10b154989f4960c14dac90f1701.

My hint is that this creates too big responses at /contributors … 

In any case, backend has been stable with this reverted (2 restarts in one week)

Note: This is already in production, by the nature of the diagnostic (see #335)