### PR TITLE
fix: cannot fetch notices by contributor

### DIFF
--- a/src/Controller/Api/GetNoticesAction.php
+++ b/src/Controller/Api/GetNoticesAction.php
@@ -32,14 +32,14 @@ class GetNoticesAction extends BaseAction
      */
     public function __invoke(Request $request): JsonResponse
     {
-        $contributorId = $request->get('contributor', null);
-        $limit = $request->get('limit', 1000);
-        $offset = $request->get('offset', 0);
+        $contributorId = (int) $request->get('contributor', null);
+        $limit = (int) $request->get('limit', 1000);
+        $offset = (int) $request->get('offset', 0);
 
         if ($contributorId) {
-            $notices = $this->repository->getPageByContributor($contributorId, (int) $limit, (int) $offset);
+            $notices = $this->repository->getPageByContributor($contributorId, $limit, $offset);
         } else {
-            $notices = $this->repository->getPage((int) $limit, (int) $offset);
+            $notices = $this->repository->getPage($limit, $offset);
         }
 
         if (!is_iterable($notices)) {


### PR DESCRIPTION
Commit fed695c806bf23e20473e496c8049cecae5f5c3e introduced `strict_types` but did not cast `contributorId` to `int`

This fixes it.

This is already in production, as it was a hotfix, and solves issue https://github.com/dis-moi/extension/issues/913 

closes https://github.com/dis-moi/extension/issues/913