### PR TITLE
chore: use collection interface as return type

### DIFF
--- a/src/Entity/Contributor.php
+++ b/src/Entity/Contributor.php
@@ -130,7 +130,7 @@ class Contributor implements ImageUploadable
     private $notices;
 
     /**
-     * @var ArrayCollection<Subscription>
+     * @var Collection<Subscription>
      *
      * @ORM\OneToMany(targetEntity=Subscription::class, mappedBy="contributor", orphanRemoval=true)
      * @ORM\OrderBy({"created"="DESC"})
@@ -187,7 +187,7 @@ class Contributor implements ImageUploadable
     private $pins;
 
     /**
-     * @var ArrayCollection<Relay>
+     * @var Collection<Relay>
      *
      * @ORM\OneToMany(targetEntity=Relay::class, mappedBy="relayedBy", cascade={"persist", "remove"}, orphanRemoval=true)
      */
@@ -204,7 +204,7 @@ class Contributor implements ImageUploadable
      * The list of Users that may impersonate this Contributor.
      * Some users with the appropriate roles may also impersonate without being referenced explicitly here. (admins).
      *
-     * @var ArrayCollection<User>
+     * @var Collection<User>
      * @ORM\ManyToMany(
      *     targetEntity=User::class,
      *     mappedBy="hats",
@@ -443,7 +443,7 @@ class Contributor implements ImageUploadable
         });
     }
 
-    public function getPublicRelays(): ArrayCollection
+    public function getPublicRelays(): Collection
     {
         return $this->getRelayedNotices()->filter(static function (Notice $notice) {
             return $notice->hasPublicVisibility();
@@ -479,11 +479,11 @@ class Contributor implements ImageUploadable
     }
 
     /**
-     * @param ArrayCollection<Notice> $givenNotices
+     * @param Collection<Notice> $givenNotices
      *
      * @return $this
      */
-    public function setPinnedNotices(ArrayCollection $givenNotices): self
+    public function setPinnedNotices(Collection $givenNotices): self
     {
         if ($givenNotices->count() > 5) {
             throw new InvalidArgumentException('No more than 5 pinned notices by contributor please');
@@ -517,7 +517,7 @@ class Contributor implements ImageUploadable
         return $this;
     }
 
-    public function getRelayedNotices(): ArrayCollection
+    public function getRelayedNotices(): Collection
     {
         return $this->relayedNotices->map(static function (Relay $relay) {
             return $relay->getNotice();
@@ -574,9 +574,9 @@ class Contributor implements ImageUploadable
     }
 
     /**
-     * @return ArrayCollection<User> those that may act as this Contributor
+     * @return Collection<User> those that may act as this Contributor
      */
-    public function getImpersonators(): ArrayCollection
+    public function getImpersonators(): Collection
     {
         return $this->impersonators;
     }

--- a/src/Entity/Extension.php
+++ b/src/Entity/Extension.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace App\Entity;
 
 use DateTime;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
-use Doctrine\ORM\PersistentCollection;
 
 /**
  * Extension.
@@ -25,7 +26,7 @@ class Extension
     private $id;
 
     /**
-     * @var PersistentCollection<Subscription>
+     * @var Collection<Subscription>
      * @ORM\OneToMany(targetEntity=Subscription::class, mappedBy="extension", orphanRemoval=true)
      * @ORM\OrderBy({"created"="DESC"})
      */
@@ -49,6 +50,7 @@ class Extension
     {
         $this->id = $id;
         $this->created = new DateTime();
+        $this->subscriptions = new ArrayCollection();
     }
 
     public function getId(): string
@@ -57,9 +59,9 @@ class Extension
     }
 
     /**
-     * @return PersistentCollection<Subscription>
+     * @return Collection<Subscription>
      */
-    public function getSubscriptions(): PersistentCollection
+    public function getSubscriptions(): Collection
     {
         return $this->subscriptions;
     }

--- a/src/Entity/Notice.php
+++ b/src/Entity/Notice.php
@@ -112,7 +112,7 @@ class Notice
     private $visibility;
 
     /**
-     * @var ArrayCollection<MatchingContext>
+     * @var Collection<MatchingContext>
      *
      * @ORM\OneToMany(targetEntity=MatchingContext::class, mappedBy="notice", cascade={"persist", "remove"}, orphanRemoval=true)
      * @ORM\JoinColumn(nullable=false)
@@ -175,7 +175,7 @@ class Notice
     private $note;
 
     /**
-     * @var ArrayCollection<Rating>
+     * @var Collection<Rating>
      *
      * @ORM\OneToMany(targetEntity=Rating::class, mappedBy="notice", cascade={"persist", "remove"}, orphanRemoval=true)
      */

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use FOS\UserBundle\Model\User as BaseUser;
 
@@ -28,7 +29,7 @@ class User extends BaseUser
     /**
      * Contributors this User may impersonate, that is can submit Notices as.
      *
-     * @var ArrayCollection<Contributor>
+     * @var Collection<Contributor>
      * @ORM\ManyToMany(
      *     targetEntity=Contributor::class,
      *     inversedBy="impersonators",
@@ -44,7 +45,7 @@ class User extends BaseUser
     }
 
     /**
-     * @return ArrayCollection<Contributor>
+     * @return Collection<Contributor>
      */
     public function getHats()
     {


### PR DESCRIPTION
This is the common interface between ArrayCollection and PeristentCollection.
However sometimes the ArrayCollection features are still used so typehintinh may differs in phpdoc.

> fix https://sentry.io/organizations/lmem/issues/2467663798/?environment=production&project=1404898