### PR TITLE
chore: add a (nicer) route for API v4

### DIFF
--- a/config/routes/api_platform.yaml
+++ b/config/routes/api_platform.yaml
@@ -2,3 +2,8 @@ api_platform:
     resource: .
     type: api_platform
     prefix: /api/v4
+
+api_v4:
+    resource: .
+    type: api_platform
+    prefix: /v4


### PR DESCRIPTION
> I added __api.dismoi.io__ as a `CNAME` record and pointed it a the backend, the idea is to get a nice route name for the API.

The idea is to get a nice URL for the API doc, with this suggestion it would be :
https://api.dismoi.io/v4

> instead of https://api.dismoi.io/api/v4

Api to hear your suggestions!