### PR TITLE
feat(domain): add aliases to a domain name

### DIFF
--- a/config/packages/easy_admin.yaml
+++ b/config/packages/easy_admin.yaml
@@ -155,6 +155,7 @@ easy_admin:
         fields:
           - { property: name, label: domains.name }
           - { property: path, label: domains.path }
+          - { property: aliases, label: domains.aliases, help: domains.aliases.help }
       show:
         max_results: 100
         fields:

--- a/migrations/Version20210907130721.php
+++ b/migrations/Version20210907130721.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20210907130721 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $this->abortIf('mysql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE domain_name ADD aliases LONGTEXT NOT NULL COMMENT \'(DC2Type:simple_array)\'');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->abortIf('mysql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE domain_name DROP aliases');
+    }
+}

--- a/src/DataFixtures/DomainFixtures.php
+++ b/src/DataFixtures/DomainFixtures.php
@@ -18,7 +18,13 @@ class DomainFixtures extends Fixture implements DependentFixtureInterface
         $manager->persist($disMoiDomain);
         $this->addReference('dismoi_domain', $disMoiDomain);
 
+        $youtubeDomain = new DomainName('youtube.com');
+        $youtubeDomain->addAlias('m.youtube.com');
+        $manager->persist($disMoiDomain);
+        $this->addReference('com_youtube_www', $youtubeDomain);
+
         $domainName1 = new DomainName('first.domainname.fr');
+        $domainName1->addAlias('alias.first.domainname.fr');
         $manager->persist($domainName1);
         $this->addReference('first_domain', $domainName1);
 

--- a/src/Entity/DomainName.php
+++ b/src/Entity/DomainName.php
@@ -21,6 +21,11 @@ class DomainName
     use ORMBehaviors\Timestampable\Timestampable;
 
     /**
+     * @see https://github.com/doctrine/orm/issues/4673
+     */
+    public const EMPTY_SIMPLE_ARRAY = [''];
+
+    /**
      * @var int
      *
      * @ORM\Column(name="id", type="integer")
@@ -68,6 +73,17 @@ class DomainName
     private $sets;
 
     /**
+     * @var string[]
+     *
+     * @ORM\Column(type="simple_array")
+     *
+     * @Assert\All({
+     *     @Assert\Regex("/^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$/")
+     * })
+     */
+    private $aliases;
+
+    /**
      * Domain constructor.
      */
     public function __construct(string $name = '')
@@ -75,6 +91,7 @@ class DomainName
         $this->name = $name;
         $this->matchingContexts = new ArrayCollection();
         $this->sets = new ArrayCollection();
+        $this->aliases = self::EMPTY_SIMPLE_ARRAY;
     }
 
     public function __toString(): string
@@ -116,6 +133,45 @@ class DomainName
     public function getSets(): Collection
     {
         return $this->sets;
+    }
+
+    /**
+     * @param string[] $aliases
+     */
+    public function setAliases(array $aliases = []): self
+    {
+        $this->aliases = array_filter($aliases, static function ($alias) {
+            return '' !== $alias;
+        }) ?: self::EMPTY_SIMPLE_ARRAY;
+
+        return $this;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getAliases(): array
+    {
+        return array_filter($this->aliases, static function ($alias) {
+            return '' !== $alias;
+        });
+    }
+
+    /**
+     * @return DomainName
+     */
+    public function addAlias(string $alias): self
+    {
+        $this->aliases = array_merge($this->aliases, [$alias]);
+
+        return $this;
+    }
+
+    public function removeAlias(string $alias): self
+    {
+        $this->aliases = array_diff($this->aliases, [$alias]);
+
+        return $this;
     }
 
     /**

--- a/src/Entity/MatchingContext.php
+++ b/src/Entity/MatchingContext.php
@@ -266,9 +266,15 @@ class MatchingContext
 
         return '('.implode(
             '|',
-            array_map(static function (DomainName $dn) use ($escaper) {
-                return escape($dn->getFullName(), $escaper);
-            }, $domains)
+                array_reduce($domains, static function ($accumulator, DomainName $dn) use ($escaper) {
+                    return array_merge(
+                        $accumulator,
+                        [escape($dn->getFullName(), $escaper)],
+                        array_map(static function (string $alias) use ($escaper) {
+                            return escape($alias, $escaper);
+                        }, $dn->getAliases())
+                    );
+                }, [])
         ).')'.$this->urlRegex;
     }
 

--- a/tests/Entity/MatchingContextTest.php
+++ b/tests/Entity/MatchingContextTest.php
@@ -25,10 +25,10 @@ class MatchingContextTest extends FixtureAwareWebTestCase
         /** @var MatchingContext $mc */
         $mc = $this->referenceRepository->getReference('mc_with_domain_name');
         $regex = $mc->getFullUrlRegex($escaper);
-        self::assertEquals('(duckduckgo.com|www.bing.com|www.google.fr|www.qwant.com|www.yahoo.com|first.domainname.fr|second.domainname.fr)'.$mc->getUrlRegex(), $regex);
+        self::assertEquals('(duckduckgo.com|www.bing.com|www.google.fr|www.qwant.com|www.yahoo.com|first.domainname.fr|alias.first.domainname.fr|second.domainname.fr)'.$mc->getUrlRegex(), $regex);
 
         $regex = $mc->getFullUrlRegex();
-        self::assertEquals('(duckduckgo.com|www.bing.com|www.google.fr|www.qwant.com|www.yahoo.com|first.domainname.fr|second.domainname.fr)'.$mc->getUrlRegex(), $regex);
+        self::assertEquals('(duckduckgo.com|www.bing.com|www.google.fr|www.qwant.com|www.yahoo.com|first.domainname.fr|alias.first.domainname.fr|second.domainname.fr)'.$mc->getUrlRegex(), $regex);
 
         /** @var MatchingContext $mc */
         $mc = $this->referenceRepository->getReference('mc_without_domain_name');

--- a/translations/messages.fr.yml
+++ b/translations/messages.fr.yml
@@ -85,6 +85,8 @@ domains:
   name: Nom du domaine
   path: Chemin
   sets: Groupes de domaines liés
+  aliases: Aliases
+  aliases.help: "Par exemple <i>m.youtube.com</i> pour <i>www.youtube.com</i>."
   sets.nb: Nb de groupes de domaines liés
   matchingContexts: Pages cibles liées
   matchingContexts.nb: Nb d’ensemble de pages cibles liées


### PR DESCRIPTION
Aliases are mapped to a simple php array, there is a little hack to overcome an issue with Doctrine's `simple_array` which maps the `[]` to `null` in database, hence the oddities you can see in the `DomainName` entity.

This also update the "big" regexp we expose with the possible aliases of domain. (see updated tests for example of generated regexp).

The same validation rule as a `Domain` `name` has been added to each `aliases` element but both seems to be ignored by __ZiziAdmin__...

> This fix issue #429 :kiss: