### PR TITLE
feat(matching-context): expose list of domains in API

### DIFF
--- a/src/Entity/MatchingContext.php
+++ b/src/Entity/MatchingContext.php
@@ -257,25 +257,39 @@ class MatchingContext
         return $this->urlRegex;
     }
 
-    public function getFullUrlRegex(Escaper $escaper = null): string
+    /**
+     * @Groups({
+     *     "read"
+     * })
+     *
+     * @return string[]
+     */
+    public function getDomains(Escaper $escaper = null): array
     {
         $domains = $this->getAllRelatedDomains();
         if (0 === \count($domains)) {
-            return $this->urlRegex;
+            return [];
         }
 
-        return '('.implode(
-            '|',
-                array_reduce($domains, static function ($accumulator, DomainName $dn) use ($escaper) {
-                    return array_merge(
+        return array_reduce($domains, static function ($accumulator, DomainName $dn) use ($escaper) {
+            return array_merge(
                         $accumulator,
                         [escape($dn->getFullName(), $escaper)],
                         array_map(static function (string $alias) use ($escaper) {
                             return escape($alias, $escaper);
                         }, $dn->getAliases())
                     );
-                }, [])
-        ).')'.$this->urlRegex;
+        }, []);
+    }
+
+    public function getFullUrlRegex(Escaper $escaper = null): string
+    {
+        $domains = $this->getDomains();
+        if (0 === \count($domains)) {
+            return $this->urlRegex;
+        }
+
+        return '('.implode('|', $domains).')'.$this->urlRegex;
     }
 
     /**

--- a/src/Serializer/V3/MatchingContextNormalizer.php
+++ b/src/Serializer/V3/MatchingContextNormalizer.php
@@ -55,12 +55,16 @@ class MatchingContextNormalizer implements ContextAwareNormalizerInterface
 
         return array_filter([
             'id' => $matchingContext->getId(),
+            'domains' => $matchingContext->getDomains(),
             'noticeId' => $matchingContext->getNotice()->getId(),
             'noticeUrl' => $this->router->generate(
                 'app_api_v3_getnoticeaction__invoke',
                 ['id' => $matchingContext->getNotice()->getId()],
                 RouterInterface::ABSOLUTE_URL),
+            // @todo should be renamed `fullUrlRegex` in next major release
             'urlRegex' => $matchingContext->getFullUrlRegex($this->escaper),
+            // @todo should probably be named `urlRegex` in next major release
+            'urlPathRegex' => $matchingContext->getUrlRegex(),
             'excludeUrlRegex' => $matchingContext->getCompleteExcludeUrlRegex(),
             'querySelector' => $matchingContext->getQuerySelector(),
             'xpath' => $matchingContext->getXpath(),

--- a/tests/Entity/MatchingContextTest.php
+++ b/tests/Entity/MatchingContextTest.php
@@ -24,6 +24,10 @@ class MatchingContextTest extends FixtureAwareWebTestCase
 
         /** @var MatchingContext $mc */
         $mc = $this->referenceRepository->getReference('mc_with_domain_name');
+
+        $domains = $mc->getDomains($escaper);
+        self::assertEquals(['duckduckgo.com', 'www.bing.com', 'www.google.fr', 'www.qwant.com', 'www.yahoo.com', 'first.domainname.fr', 'alias.first.domainname.fr', 'second.domainname.fr'], $domains);
+
         $regex = $mc->getFullUrlRegex($escaper);
         self::assertEquals('(duckduckgo.com|www.bing.com|www.google.fr|www.qwant.com|www.yahoo.com|first.domainname.fr|alias.first.domainname.fr|second.domainname.fr)'.$mc->getUrlRegex(), $regex);
 


### PR DESCRIPTION
Exposes the list of domains on which a matching context is applicable. It also exposes the *path* part of the regexp uses in mathching context...

Some current and previous vocabulary seems dodgy... maybe a `DomainName` should be renamed to `Domain` so we can use `domainName` only for the actual string version of the domain name...

Also `urlPathRegex` is not truly a *path* __regex__ since the user can choose to match all domains... is that still supposed to be possible?

> fix #446