### PR TITLE
feat(matching): introduce product matching engine

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -80,7 +80,8 @@
         "friendsofphp/php-cs-fixer": "^2.16",
         "rector/rector": "^0.8.15",
         "brainmaestro/composer-git-hooks": "^2.8",
-        "phpstan/phpstan": "^0.12.83"
+        "phpstan/phpstan": "^0.12.83",
+        "api-platform/schema-generator": "^2.2"
     },
     "conflict": {
         "symfony/symfony": "*"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "638853bc759f2e3cf242701d568428a9",
+    "content-hash": "53056374459b244bbbcf2f9005c6acbc",
     "packages": [
         {
             "name": "api-platform/core",
@@ -11121,6 +11121,79 @@
     ],
     "packages-dev": [
         {
+            "name": "api-platform/schema-generator",
+            "version": "v2.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/api-platform/schema-generator.git",
+                "reference": "2938bd2f2dd586f7edafb344f0adca90b100de6b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/api-platform/schema-generator/zipball/2938bd2f2dd586f7edafb344f0adca90b100de6b",
+                "reference": "2938bd2f2dd586f7edafb344f0adca90b100de6b",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/inflector": "^1.0",
+                "easyrdf/easyrdf": "^0.9",
+                "ext-json": "*",
+                "friendsofphp/php-cs-fixer": "^2.15",
+                "league/html-to-markdown": "^4.0",
+                "php": ">=7.1",
+                "psr/log": "^1.0",
+                "symfony/config": "^3.3 || ^4.0 || ^5.0",
+                "symfony/console": "^2.7 || ^3.0 || ^4.0 || ^5.0",
+                "symfony/yaml": "^2.7 || ^3.0 || ^4.0 || ^5.0",
+                "twig/twig": "^1.35 || ^2.0 || ^3.0"
+            },
+            "require-dev": {
+                "api-platform/core": "^2.0",
+                "doctrine/orm": "^2.2",
+                "myclabs/php-enum": "^1.0",
+                "symfony/doctrine-bridge": "^2.7 || ^3.0 || ^4.0 || ^5.0",
+                "symfony/filesystem": "^2.7 || ^3.0 || ^4.0 || ^5.0",
+                "symfony/phpunit-bridge": "^4.3 || ^5.0",
+                "symfony/serializer": "^2.7 || ^3.0 || ^4.0 || ^5.0",
+                "symfony/validator": "^2.7 || ^3.0 || ^4.0 || ^5.0"
+            },
+            "bin": [
+                "bin/schema"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "ApiPlatform\\SchemaGenerator\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kévin Dunglas",
+                    "email": "dunglas@gmail.com"
+                }
+            ],
+            "description": "Various tools to generate a data model based on Schema.org vocables",
+            "homepage": "https://api-platform.com",
+            "keywords": [
+                "doctrine",
+                "entity",
+                "enum",
+                "model",
+                "schema.org",
+                "semantic",
+                "symfony"
+            ],
+            "support": {
+                "issues": "https://github.com/api-platform/schema-generator/issues",
+                "source": "https://github.com/api-platform/schema-generator/tree/master"
+            },
+            "time": "2020-01-10T10:52:36+00:00"
+        },
+        {
             "name": "brainmaestro/composer-git-hooks",
             "version": "v2.8.5",
             "source": {
@@ -11505,6 +11578,74 @@
             "time": "2020-09-01T07:06:14+00:00"
         },
         {
+            "name": "easyrdf/easyrdf",
+            "version": "0.9.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/easyrdf/easyrdf.git",
+                "reference": "acd09dfe0555fbcfa254291e433c45fdd4652566"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/easyrdf/easyrdf/zipball/acd09dfe0555fbcfa254291e433c45fdd4652566",
+                "reference": "acd09dfe0555fbcfa254291e433c45fdd4652566",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "ext-pcre": "*",
+                "php": ">=5.2.8"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~3.5",
+                "sami/sami": "~1.4",
+                "squizlabs/php_codesniffer": "~1.4.3"
+            },
+            "suggest": {
+                "ml/json-ld": "~1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "EasyRdf_": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nicholas Humfrey",
+                    "email": "njh@aelius.com",
+                    "homepage": "http://www.aelius.com/njh/",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Alexey Zakhlestin",
+                    "email": "indeyets@gmail.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "EasyRdf is a PHP library designed to make it easy to consume and produce RDF.",
+            "homepage": "http://www.easyrdf.org/",
+            "keywords": [
+                "Linked Data",
+                "RDF",
+                "Semantic Web",
+                "Turtle",
+                "rdfa",
+                "sparql"
+            ],
+            "support": {
+                "forum": "http://groups.google.com/group/easyrdf/",
+                "irc": "irc://chat.freenode.net/easyrdf",
+                "issues": "http://github.com/njh/easyrdf/issues",
+                "source": "https://github.com/easyrdf/easyrdf/tree/0.9.1"
+            },
+            "time": "2015-02-27T09:45:49+00:00"
+        },
+        {
             "name": "friendsofphp/php-cs-fixer",
             "version": "v2.16.7",
             "source": {
@@ -11604,6 +11745,92 @@
                 }
             ],
             "time": "2020-10-27T22:44:27+00:00"
+        },
+        {
+            "name": "league/html-to-markdown",
+            "version": "4.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/html-to-markdown.git",
+                "reference": "0868ae7a552e809e5cd8f93ba022071640408e88"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/html-to-markdown/zipball/0868ae7a552e809e5cd8f93ba022071640408e88",
+                "reference": "0868ae7a552e809e5cd8f93ba022071640408e88",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-xml": "*",
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "mikehaertl/php-shellcommand": "~1.1.0",
+                "phpunit/phpunit": "^4.8|^5.7",
+                "scrutinizer/ocular": "~1.1"
+            },
+            "bin": [
+                "bin/html-to-markdown"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.10-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\HTMLToMarkdown\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Colin O'Dell",
+                    "email": "colinodell@gmail.com",
+                    "homepage": "https://www.colinodell.com",
+                    "role": "Lead Developer"
+                },
+                {
+                    "name": "Nick Cernis",
+                    "email": "nick@cern.is",
+                    "homepage": "http://modernnerd.net",
+                    "role": "Original Author"
+                }
+            ],
+            "description": "An HTML-to-markdown conversion helper for PHP",
+            "homepage": "https://github.com/thephpleague/html-to-markdown",
+            "keywords": [
+                "html",
+                "markdown"
+            ],
+            "support": {
+                "issues": "https://github.com/thephpleague/html-to-markdown/issues",
+                "source": "https://github.com/thephpleague/html-to-markdown/tree/4.10.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.colinodell.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.paypal.me/colinpodell/10.00",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/colinodell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/colinodell",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2020-07-01T00:34:03+00:00"
         },
         {
             "name": "migrify/migrify-kernel",

--- a/config/schema_generator.yaml
+++ b/config/schema_generator.yaml
@@ -1,0 +1,40 @@
+id:
+  generate: true
+
+namespaces:
+  entity: "App\\Entity"
+
+
+# The list of types and properties we want to use
+types:
+  Thing:
+    embeddable: false
+    properties:
+      name: ~
+      alternateName: ~
+      description: ~
+  Product:
+    parent: "Thing"
+    embeddable: false
+    properties:
+      # Force the type of the property to text
+      category:
+        range: "Text"
+        cardinality: "(0..1)"
+      offers:
+        range: "Offer"
+        embedded: true
+        columnPrefix: "offer_"
+        cardinality: "(0..1)"
+  Offer:
+    # Disable the generation of the class hierarchy for this type
+    parent: false
+    embeddable: true
+    properties:
+      # Force the type of the addressCountry property to text
+      availableAtOrFrom:
+        range: "Text"
+        cardinality: "(0..1)"
+      price:
+        range: "Number"
+        cardinality: "(0..1)"

--- a/docs/schema_generator.md
+++ b/docs/schema_generator.md
@@ -1,0 +1,16 @@
+# Schema generator
+
+Some entities were bootstrapped using the api-platform schema-generator:
+https://api-platform.com/docs/schema-generator/
+
+The generator uses the vocabulary formalized on [schema.org](https://schema.org).
+
+## Configuration
+
+[config/schema_generator.yaml](config/schema_generator.yaml)
+
+## Generation
+
+```shell
+docker-compose exec php vendor/bin/schema generate src/ config/schema_generator.yaml
+```

--- a/migrations/Version20210922155023.php
+++ b/migrations/Version20210922155023.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * On custom index and foreign key names:
+ * https://stackoverflow.com/questions/7623958/naming-a-relation-in-doctrine-2-orm.
+ */
+final class Version20210922155023 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $this->abortIf('mysql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('CREATE TABLE product (id INT AUTO_INCREMENT NOT NULL, name LONGTEXT DEFAULT NULL, alternate_name LONGTEXT DEFAULT NULL, description LONGTEXT DEFAULT NULL, category LONGTEXT DEFAULT NULL, offer_available_at_or_from LONGTEXT DEFAULT NULL, offer_price DOUBLE PRECISION DEFAULT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE matching_context ADD product_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE matching_context ADD CONSTRAINT FK_matching_context_product_id FOREIGN KEY (product_id) REFERENCES product (id)');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_matching_context_product_id ON matching_context (product_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->abortIf('mysql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE matching_context DROP FOREIGN KEY FK_matching_context_product_id');
+        $this->addSql('DROP TABLE product');
+        $this->addSql('DROP INDEX UNIQ_matching_context_product_id ON matching_context');
+        $this->addSql('ALTER TABLE matching_context DROP product_id');
+    }
+}

--- a/public/css/admin.css
+++ b/public/css/admin.css
@@ -24,6 +24,19 @@
     border-radius: var(--border-radius);
 }
 
+.form-group .form-group .form-group > legend + .form-widget {
+    padding-left: 10px;
+    margin-bottom: 20px;
+    background-color: var(--fieldset-bg);
+    border: var(--border-width) var(--border-style) var(--gray-400);
+    border-radius: var(--border-radius);
+}
+
+.form-group legend.col-form-label {
+    font-weight: bold;
+    font-size: medium;
+}
+
 body.edit textarea#notice_message,
 body.edit textarea#notice_note,
 body.new textarea#notice_message,

--- a/src/Entity/MatchingContext.php
+++ b/src/Entity/MatchingContext.php
@@ -210,6 +210,19 @@ class MatchingContext
      */
     private $xpath;
 
+    /**
+     * @var Product
+     *
+     * @ORM\OneToOne(targetEntity="Product", cascade={"persist"}, orphanRemoval=true)
+     * @ORM\JoinColumn(name="product_id", referencedColumnName="id", nullable=true)
+     * @Groups({
+     *     "create",
+     *     "read",
+     *     "update",
+     * })
+     */
+    private $product = null;
+
     public function __construct()
     {
         $this->urlRegex = '';
@@ -453,5 +466,17 @@ class MatchingContext
             )),
             $this->getDomainNames()->toArray()
         ));
+    }
+
+    public function setProduct(Product $product): self
+    {
+        $this->product = $product;
+
+        return $this;
+    }
+
+    public function getProduct(): ?Product
+    {
+        return $this->product;
     }
 }

--- a/src/Entity/Offer.php
+++ b/src/Entity/Offer.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use ApiPlatform\Core\Annotation\ApiProperty;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * An offer to transfer some rights to an item or to provide a service — for example, an offer to sell tickets to an event, to rent the DVD of a movie, to stream a TV show over the internet, to repair a motorcycle, or to loan a book.\\n\\nFor \[GTIN\](http://www.gs1.org/barcodes/technical/idkeys/gtin)-related fields, see \[Check Digit calculator\](http://www.gs1.org/barcodes/support/check\_digit\_calculator) and \[validation guide\](http://www.gs1us.org/resources/standards/gtin-validation-guide) from \[GS1\](http://www.gs1.org/).
+ *
+ * @see http://schema.org/Offer Documentation on Schema.org
+ *
+ * @ORM\Embeddable
+ */
+class Offer
+{
+    /**
+     * @var string|null The place(s) from which the offer can be obtained (e.g. store locations).
+     *
+     * @ORM\Column(type="text", nullable=true)
+     * @ApiProperty(iri="http://schema.org/availableAtOrFrom")
+     */
+    private $availableAtOrFrom;
+
+    /**
+     * @var float|null The offer price of a product, or of a price component when attached to PriceSpecification and its subtypes.\\n\\nUsage guidelines:\\n\\n\* Use the \[\[priceCurrency\]\] property (with \[ISO 4217 codes\](http://en.wikipedia.org/wiki/ISO\_4217#Active\_codes) e.g. "USD") instead of including \[ambiguous symbols\](http://en.wikipedia.org/wiki/Dollar\_sign#Currencies\_that\_use\_the\_dollar\_or\_peso\_sign) such as '$' in the value.\\n\* Use '.' (Unicode 'FULL STOP' (U+002E)) rather than ',' to indicate a decimal point. Avoid using these symbols as a readability separator.\\n\* Note that both \[RDFa\](http://www.w3.org/TR/xhtml-rdfa-primer/#using-the-content-attribute) and Microdata syntax allow the use of a "content=" attribute for publishing simple machine-readable values alongside more human-friendly formatting.\\n\* Use values from 0123456789 (Unicode 'DIGIT ZERO' (U+0030) to 'DIGIT NINE' (U+0039)) rather than superficially similar Unicode symbols.
+     *
+     * @ORM\Column(type="float", nullable=true)
+     * @ApiProperty(iri="http://schema.org/price")
+     */
+    private $price;
+
+    public function setAvailableAtOrFrom(?string $availableAtOrFrom): void
+    {
+        $this->availableAtOrFrom = $availableAtOrFrom;
+    }
+
+    public function getAvailableAtOrFrom(): ?string
+    {
+        return $this->availableAtOrFrom;
+    }
+
+    /**
+     * @param float|null $price
+     */
+    public function setPrice($price): void
+    {
+        $this->price = $price;
+    }
+
+    /**
+     * @return float|null
+     */
+    public function getPrice()
+    {
+        return $this->price;
+    }
+}

--- a/src/Entity/Product.php
+++ b/src/Entity/Product.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use ApiPlatform\Core\Annotation\ApiProperty;
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Annotation\Groups;
+
+/**
+ * Any offered product or service. For example: a pair of shoes; a concert ticket; the rental of a car; a haircut; or an episode of a TV show streamed online.
+ *
+ * @see http://schema.org/Product Documentation on Schema.org
+ *
+ * @ORM\Entity
+ * @ApiResource(
+ *     iri="http://schema.org/Product",
+ *     normalizationContext={
+ *         "groups"={"read"}
+ *     }
+ * )
+ */
+class Product extends Thing
+{
+    /**
+     * @var int|null
+     *
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     * @ORM\Column(type="integer")
+     */
+    private $id;
+
+    /**
+     * @var string|null A category for the item. Greater signs or slashes can be used to informally indicate a category hierarchy.
+     *
+     * @ORM\Column(type="text", nullable=true)
+     * @ApiProperty(iri="http://schema.org/category")
+     * @Groups({
+     *     "read"
+     * })
+     */
+    private $category;
+
+    /**
+     * @var Offer|null an offer to provide this item—for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event
+     *
+     * @ORM\Embedded(class="App\Entity\Offer", columnPrefix="offer_")
+     * @ApiProperty(iri="http://schema.org/offers")
+     * @Groups({
+     *     "read"
+     * })
+     */
+    private $offer;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setCategory(?string $category): void
+    {
+        $this->category = $category;
+    }
+
+    public function getCategory(): ?string
+    {
+        return $this->category;
+    }
+
+    public function setOffer(?Offer $offer): void
+    {
+        $this->offer = $offer;
+    }
+
+    public function getOffer(): ?Offer
+    {
+        return $this->offer;
+    }
+}

--- a/src/Entity/Thing.php
+++ b/src/Entity/Thing.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use ApiPlatform\Core\Annotation\ApiProperty;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Annotation\Groups;
+
+/**
+ * The most generic type of item.
+ *
+ * @see http://schema.org/Thing Documentation on Schema.org
+ *
+ * @ORM\MappedSuperclass
+ */
+abstract class Thing
+{
+    /**
+     * @var string|null the name of the item
+     *
+     * @ORM\Column(type="text", nullable=true)
+     * @ApiProperty(iri="http://schema.org/name")
+     * @Groups({
+     *     "read"
+     * })
+     */
+    private $name;
+
+    /**
+     * @var string|null an alias for the item
+     *
+     * @ORM\Column(type="text", nullable=true)
+     * @ApiProperty(iri="http://schema.org/alternateName")
+     */
+    private $alternateName;
+
+    /**
+     * @var string|null a description of the item
+     *
+     * @ORM\Column(type="text", nullable=true)
+     * @ApiProperty(iri="http://schema.org/description")
+     * @Groups({
+     *     "read"
+     * })
+     */
+    private $description;
+
+    public function setName(?string $name): void
+    {
+        $this->name = $name;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setAlternateName(?string $alternateName): void
+    {
+        $this->alternateName = $alternateName;
+    }
+
+    public function getAlternateName(): ?string
+    {
+        return $this->alternateName;
+    }
+
+    public function setDescription(?string $description): void
+    {
+        $this->description = $description;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+}

--- a/src/Form/MatchingContextType.php
+++ b/src/Form/MatchingContextType.php
@@ -68,6 +68,10 @@ class MatchingContextType extends AbstractType
             ->add('description', TextType::class, [
                 'required' => false,
                 'label' => 'matchingContexts.description',
+            ])
+            ->add('product', ProductType::class, [
+                'required' => false,
+                'label' => 'matching_context.product',
             ]);
     }
 

--- a/src/Form/OfferType.php
+++ b/src/Form/OfferType.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Form;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\MoneyType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class OfferType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('availableAtOrFrom', TextType::class, [
+                'required' => false,
+                'label' => 'offer.availableAtOrFrom',
+            ])
+            ->add('price', MoneyType::class, [
+                'required' => false,
+                'label' => 'offer.price',
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => 'App\Entity\Offer',
+        ]);
+    }
+}

--- a/src/Form/ProductType.php
+++ b/src/Form/ProductType.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Form;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class ProductType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('name', TextType::class, [
+                'required' => false,
+                'label' => 'product.name',
+            ])
+            ->add('category', TextType::class, [
+                'required' => false,
+                'label' => 'product.category',
+            ])
+            ->add('description', TextType::class, [
+                'required' => false,
+                'label' => 'product.description',
+            ])
+            ->add('offer', OfferType::class, [
+                'required' => false,
+                'label' => 'product.offer',
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => 'App\Entity\Product',
+        ]);
+    }
+}

--- a/src/Serializer/V3/MatchingContextNormalizer.php
+++ b/src/Serializer/V3/MatchingContextNormalizer.php
@@ -9,9 +9,16 @@ use App\Helper\PregEscaper;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\Normalizer\ContextAwareNormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
-class MatchingContextNormalizer implements ContextAwareNormalizerInterface
+class MatchingContextNormalizer implements ContextAwareNormalizerInterface, NormalizerAwareInterface
 {
+    /**
+     * @var NormalizerInterface
+     */
+    protected $normalizer;
+
     /**
      * @var RouterInterface
      */
@@ -26,6 +33,11 @@ class MatchingContextNormalizer implements ContextAwareNormalizerInterface
     {
         $this->router = $router;
         $this->escaper = $escaper;
+    }
+
+    public function setNormalizer(NormalizerInterface $normalizer): void
+    {
+        $this->normalizer = $normalizer;
     }
 
     /**
@@ -68,6 +80,7 @@ class MatchingContextNormalizer implements ContextAwareNormalizerInterface
             'excludeUrlRegex' => $matchingContext->getCompleteExcludeUrlRegex(),
             'querySelector' => $matchingContext->getQuerySelector(),
             'xpath' => $matchingContext->getXpath(),
+            'product' => $this->normalizer->normalize($matchingContext->getProduct(), $format, $context),
         ]);
     }
 }

--- a/symfony.lock
+++ b/symfony.lock
@@ -16,6 +16,9 @@
             "src/Entity/.gitignore"
         ]
     },
+    "api-platform/schema-generator": {
+        "version": "v2.2.2"
+    },
     "beberlei/doctrineextensions": {
         "version": "v1.2.7"
     },
@@ -153,6 +156,9 @@
             "config/routes/easy_admin.yaml"
         ]
     },
+    "easyrdf/easyrdf": {
+        "version": "0.9.1"
+    },
     "egulias/email-validator": {
         "version": "2.1.22"
     },
@@ -227,6 +233,9 @@
     },
     "lcobucci/jwt": {
         "version": "3.4.5"
+    },
+    "league/html-to-markdown": {
+        "version": "4.10.0"
     },
     "league/uri": {
         "version": "6.3.0"

--- a/translations/messages.fr.yml
+++ b/translations/messages.fr.yml
@@ -77,6 +77,19 @@ matchingContexts:
   excludeUrlRegex: Regex d'exclusion
   notice: Bulle
 
+matching_context:
+  product: Produit
+
+product:
+  name: Nom
+  category: Catégorie
+  description: Description
+  offer: Offre
+
+offer:
+  availableAtOrFrom: Ville
+  price: Prix
+
 restrictedContexts:
   urlRegex: URL Regex d’exclusion globale
 


### PR DESCRIPTION
Uses part of the https://schema.org vocabulary.
Make use of the api platform schema generator to bootstrap entities.

> resolves #448

This still miss a few tests and CS and stan analysis fixes but the concept is already reviewable @JalilArfaoui 

![Screenshot from 2021-09-22 18-14-38](https://user-images.githubusercontent.com/568769/134463623-03af354b-a928-4cdd-a2ed-2f59995381e3.png)
